### PR TITLE
readme tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A utility to help in building Dart command-line apps.
 
-In particular, ``cli_util`` provides a simple, standardized way to get the
-current SDK directory.  Useful, especially, when building client applications
-that interact with the Dart SDK (such as the [analyzer][analyzer]).
+In particular, `cli_util` provides a simple, standardized way to get the current
+SDK directory.  Useful, especially, when building client applications that
+interact with the Dart SDK (such as the [analyzer][analyzer]).
 
 ## Usage
 


### PR DESCRIPTION
- `Utilities` ==> `A utility`
- remove the `Install` section, as that was describing a way to install a command-line utility, and I think this is more a library used by cli apps.

@pq 
