### PR TITLE
Find SDK properly when invoked from inside SDK tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.1+3
+
+- Find SDK properly when invoked from inside SDK tests.
+
 ## 0.0.1+2
 
 - Support an executable in a symlinked directory.

--- a/lib/cli_util.dart
+++ b/lib/cli_util.dart
@@ -33,7 +33,14 @@ Directory getSdkDir([List<String> cliArgs]) {
   }
 
   // Look relative to the dart executable.
-  Directory sdkDirectory = new File(Platform.executable).parent.parent;
+  File platformExecutable = new File(Platform.executable);
+  Directory sdkDirectory = platformExecutable.parent.parent;
+  if (_isSdkDir(sdkDirectory)) return sdkDirectory;
+
+  // Handle the case where Platform.executable is a sibling of the SDK directory
+  // (this happens during internal testing).
+  sdkDirectory =
+      new Directory(p.join(platformExecutable.parent.path, 'dart-sdk'));
   if (_isSdkDir(sdkDirectory)) return sdkDirectory;
 
   // Try and locate the VM using 'which'.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_util
-version: 0.0.1+2
+version: 0.0.1+3
 author: Dart Team <misc@dartlang.org>
 description: A library to help in building Dart command-line apps.
 homepage: https://github.com/dart-lang/cli_util


### PR DESCRIPTION
Without this, tests inside the SDK repo will try to use the version of
the SDK that is installed on the user's machine, not the version that
was built from the SDK repo.