### PR TITLE
Changes for landing https://github.com/dart-lang/sdk/issues/32161

### DIFF
--- a/test/cli_util_test.dart
+++ b/test/cli_util_test.dart
@@ -8,7 +8,7 @@ import 'package:cli_util/cli_util.dart';
 import 'package:cli_util/src/utils.dart';
 import 'package:test/test.dart';
 
-main() => defineTests();
+void main() => defineTests();
 
 void defineTests() {
   group('getSdkDir', () {


### PR DESCRIPTION
Add void declarations to methods with implicit dynamic returning void
values, which may be illegal in dart 2, but in either case, expresses
the current intent better.