### PR TITLE
Change verbose logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: dart
+dart:
+  - dev
 script: ./tool/travis.sh
 dist: trusty
 sudo: false
+
+branches:
+  only:
+    - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.3
+- In verbose mode, instead of printing the diff from the last log message,
+  print the total time since the tool started
+- Change to not buffer the last log message sent in verbose logging mode
+- Expose more classes from the logging library
+
 ## 0.1.2+1
 
 - Remove unneeded change to Dart SDK constraint.

--- a/example/main.dart
+++ b/example/main.dart
@@ -21,5 +21,6 @@ main(List<String> args) async {
   progress.finish(showTiming: true);
 
   logger.stdout('All ${logger.ansi.emphasized('done')}.');
+  // ignore: deprecated_member_use
   logger.flush();
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -21,6 +21,4 @@ main(List<String> args) async {
   progress.finish(showTiming: true);
 
   logger.stdout('All ${logger.ansi.emphasized('done')}.');
-  // ignore: deprecated_member_use
-  logger.flush();
 }

--- a/lib/cli_logging.dart
+++ b/lib/cli_logging.dart
@@ -268,23 +268,19 @@ class VerboseLogger implements Logger {
       return '';
     }
 
-    int millis = _timer.elapsedMilliseconds;
-    int seconds = millis ~/ 1000;
+    double seconds = _timer.elapsedMilliseconds / 1000.0;
     int minutes = seconds ~/ 60;
-
-    millis = millis % 1000;
-    seconds = seconds % 60;
+    seconds -= minutes * 60.0;
 
     StringBuffer buf = new StringBuffer();
     if (minutes > 0) {
-      buf.write(minutes);
-      buf.write(':');
+      buf.write((minutes % 60));
+      buf.write('m ');
     }
 
-    buf.write(seconds.toString().padLeft(minutes > 0 ? 2 : 1, '0'));
-    buf.write('.');
-    buf.write(millis.toString().padLeft(3, '0'));
+    buf.write(seconds.toStringAsFixed(3).padLeft(minutes > 0 ? 6 : 1, '0'));
+    buf.write('s');
 
-    return '[${buf.toString().padLeft(9)}] ';
+    return '[${buf.toString().padLeft(11)}] ';
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_util
-version: 0.1.2+1
+version: 0.1.3
 author: Dart Team <misc@dartlang.org>
 description: A library to help in building Dart command-line apps.
 homepage: https://github.com/dart-lang/cli_util

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -15,6 +15,9 @@ dartanalyzer --fatal-warnings \
 # Run the tests.
 dart test/cli_util_test.dart
 
+# Ensure we can run in Dart 2.
+dart --preview-dart-2 example/main.dart
+
 # Install dart_coveralls; gather and send coverage data.
 if [ "$COVERALLS_TOKEN" ]; then
   pub global activate dart_coveralls


### PR DESCRIPTION
- in verbose mode, instead of printing the diff from the last log message, print the total time since the tool started
- change to not buffer the last log message sent in verbose logging mode
- expose more classes from the logging library

@pq 