### PR TITLE
Fix dart:io constants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.3+1
+- Update Dart SDK to 2.0.0-dev.
+
 ## 0.1.3
 - In verbose mode, instead of printing the diff from the last log message,
   print the total time since the tool started

--- a/lib/cli_logging.dart
+++ b/lib/cli_logging.dart
@@ -15,7 +15,7 @@ class Ansi {
   /// Return whether the current stdout terminal supports ANSI escape sequences.
   static bool get terminalSupportsAnsi {
     return io.stdout.supportsAnsiEscapes &&
-        io.stdioType(io.stdout) == io.StdioType.TERMINAL;
+        io.stdioType(io.stdout) == io.StdioType.terminal;
   }
 
   final bool useAnsi;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: A library to help in building Dart command-line apps.
 homepage: https://github.com/dart-lang/cli_util
 
 environment:
-  sdk: '>=1.11.0 <2.0.0'
+  sdk: '>=2.0.0-dev.55.0 <3.0.0'
 
 dependencies:
   path: '>=1.0.0 <2.0.0'


### PR DESCRIPTION
Stop using the deprecated upper-case constants.