### PR TITLE
Add Ansi.reversed getter, and prepare to publish version 0.1.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.4
+- Add `Ansi.reversed` getter.
+
 ## 0.1.3+2
 - Update Dart SDK constraint to < 3.0.0.
 

--- a/lib/cli_logging.dart
+++ b/lib/cli_logging.dart
@@ -42,6 +42,8 @@ class Ansi {
 
   String get bold => _code('\u001b[1m');
 
+  String get reversed => _code('\u001b[7m');
+
   String get backspace => '\b';
 
   String get bullet => io.stdout.supportsAnsiEscapes ? '•' : '-';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_util
-version: 0.1.3+2
+version: 0.1.4
 author: Dart Team <misc@dartlang.org>
 description: A library to help in building Dart command-line apps.
 homepage: https://github.com/dart-lang/cli_util


### PR DESCRIPTION
This is needed by the NNBD migration engine to display diffs.