### PR TITLE
Add write() and writeCharCode() to Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,22 @@
+## 0.2.0
+
+- Add `Logger.write` and `Logger.writeCharCode` methods which write without
+  printing a trailing newline.
+
 ## 0.1.4
+
 - Add `Ansi.reversed` getter.
 
 ## 0.1.3+2
+
 - Update Dart SDK constraint to < 3.0.0.
 
 ## 0.1.3+1
+
 - Update Dart SDK to 2.0.0-dev.
 
 ## 0.1.3
+
 - In verbose mode, instead of printing the diff from the last log message,
   print the total time since the tool started
 - Change to not buffer the last log message sent in verbose logging mode

--- a/lib/cli_logging.dart
+++ b/lib/cli_logging.dart
@@ -86,6 +86,12 @@ abstract class Logger {
   /// Print trace output.
   void trace(String message);
 
+  /// Print text to stdout, without a trailing newline.
+  void write(String message);
+
+  /// Print a character code to stdout, without a trailing newline.
+  void writeCharCode(int charCode);
+
   /// Start an indeterminate progress display.
   Progress progress(String message);
 
@@ -122,26 +128,38 @@ class StandardLogger implements Logger {
   Progress _currentProgress;
 
   void stderr(String message) {
-    if (_currentProgress != null) {
-      Progress progress = _currentProgress;
-      _currentProgress = null;
-      progress.cancel();
-    }
+    _cancelProgress();
 
     io.stderr.writeln(message);
   }
 
   void stdout(String message) {
-    if (_currentProgress != null) {
-      Progress progress = _currentProgress;
-      _currentProgress = null;
-      progress.cancel();
-    }
+    _cancelProgress();
 
     print(message);
   }
 
   void trace(String message) {}
+
+  void write(String message) {
+    _cancelProgress();
+
+    io.stdout.write(message);
+  }
+
+  void writeCharCode(int charCode) {
+    _cancelProgress();
+
+    io.stdout.writeCharCode(charCode);
+  }
+
+  void _cancelProgress() {
+    if (_currentProgress != null) {
+      Progress progress = _currentProgress;
+      _currentProgress = null;
+      progress.cancel();
+    }
+  }
 
   Progress progress(String message) {
     if (_currentProgress != null) {
@@ -258,6 +276,14 @@ class VerboseLogger implements Logger {
 
   void trace(String message) {
     io.stdout.writeln('${_createPrefix()}${ansi.gray}$message${ansi.none}');
+  }
+
+  void write(String message) {
+    io.stdout.write(message);
+  }
+
+  void writeCharCode(int charCode) {
+    io.stdout.writeCharCode(charCode);
   }
 
   Progress progress(String message) => new SimpleProgress(this, message);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_util
-version: 0.1.4
+version: 0.2.0
 author: Dart Team <misc@dartlang.org>
 description: A library to help in building Dart command-line apps.
 homepage: https://github.com/dart-lang/cli_util


### PR DESCRIPTION
Fixes #41 

Adding public methods to subclassable public classes is a breaking change, for implementors, so I guess this should be a major version bump?