### PR TITLE
Use late final for _timer fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-nullsafety.0-dev
+## 0.3.0-nullsafety.0
 
 - Updated to support 2.12.0 and null safety.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 0.3.0-nullsafety
+## 0.3.0-nullsafety.0-dev
+
 - Updated to support 2.12.0 and null safety.
 
 ## 0.2.1

--- a/lib/cli_logging.dart
+++ b/lib/cli_logging.dart
@@ -201,16 +201,13 @@ class AnsiProgress extends Progress {
   final Ansi ansi;
 
   int _index = 0;
-  late Timer _timer;
+  late final _timer = Timer.periodic(Duration(milliseconds: 80), (t) {
+    _index++;
+    _updateDisplay();
+  });
 
   AnsiProgress(this.ansi, String message) : super(message) {
     io.stdout.write('${message}...  '.padRight(40));
-
-    _timer = Timer.periodic(Duration(milliseconds: 80), (t) {
-      _index++;
-      _updateDisplay();
-    });
-
     _updateDisplay();
   }
 
@@ -258,12 +255,10 @@ class VerboseLogger implements Logger {
   @override
   Ansi ansi;
   bool logTime;
-  late Stopwatch _timer;
+  final _timer = Stopwatch()..start();
 
   VerboseLogger({Ansi? ansi, this.logTime = false})
-      : ansi = ansi ?? Ansi(Ansi.terminalSupportsAnsi) {
-    _timer = Stopwatch()..start();
-  }
+      : ansi = ansi ?? Ansi(Ansi.terminalSupportsAnsi);
 
   @override
   bool get isVerbose => true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_util
-version: 0.3.0-nullsafety.0
+version: 0.3.0-nullsafety.0-dev
 description: A library to help in building Dart command-line apps.
 homepage: https://github.com/dart-lang/cli_util
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_util
-version: 0.3.0-nullsafety.0-dev
+version: 0.3.0-nullsafety.0
 description: A library to help in building Dart command-line apps.
 homepage: https://github.com/dart-lang/cli_util
 


### PR DESCRIPTION
The field in `AnsiProgress`had been non-final so that it could be
initialized in the constructor, the initialization expression needs
access to `this`. With null safety this pattern can be expressed with a
`late final` field.

The field in `VerboseLogger` could have been `final` before the
migration.

Append `-dev` to the version since this can't be published until it is
rolled and validated internally.