### PR TITLE
Make applicationConfigHome failures catchable

### DIFF
--- a/lib/cli_util.dart
+++ b/lib/cli_util.dart
@@ -80,7 +80,7 @@ String getSdkPath() => path.dirname(path.dirname(Platform.resolvedExecutable));
 /// [XDG Base Directory Specification][1] on Linux and [File System Basics][2]
 /// on Mac OS.
 ///
-/// Throws if `%APPDATA%` or `$HOME` is undefined.
+/// Throws an IOException if `%APPDATA%` or `$HOME` is needed but undefined.
 ///
 /// [1]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 /// [2]: https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW1
@@ -91,7 +91,8 @@ String get _configHome {
   if (Platform.isWindows) {
     final appdata = Platform.environment['APPDATA'];
     if (appdata == null) {
-      throw StateError('Environment variable %APPDATA% is not defined!');
+      throw _NoEnvironmentFoundException(
+          'Environment variable %APPDATA% is not defined!');
     }
     return appdata;
   }
@@ -118,7 +119,17 @@ String get _configHome {
 String get _home {
   final home = Platform.environment['HOME'];
   if (home == null) {
-    throw StateError('Environment variable \$HOME is not defined!');
+    throw _NoEnvironmentFoundException(
+        'Environment variable \$HOME is not defined!');
   }
   return home;
+}
+
+class _NoEnvironmentFoundException implements IOException {
+  final String message;
+  _NoEnvironmentFoundException(this.message);
+  @override
+  String toString() {
+    return message;
+  }
 }

--- a/lib/cli_util.dart
+++ b/lib/cli_util.dart
@@ -80,7 +80,8 @@ String getSdkPath() => path.dirname(path.dirname(Platform.resolvedExecutable));
 /// [XDG Base Directory Specification][1] on Linux and [File System Basics][2]
 /// on Mac OS.
 ///
-/// Throws an IOException if `%APPDATA%` or `$HOME` is needed but undefined.
+/// Throws an [EnvironmentNotFoundException] if `%APPDATA%` or `$HOME` is needed
+/// but undefined.
 ///
 /// [1]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 /// [2]: https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW1
@@ -91,7 +92,7 @@ String get _configHome {
   if (Platform.isWindows) {
     final appdata = Platform.environment['APPDATA'];
     if (appdata == null) {
-      throw _NoEnvironmentFoundException(
+      throw EnvironmentNotFoundException(
           'Environment variable %APPDATA% is not defined!');
     }
     return appdata;
@@ -119,15 +120,15 @@ String get _configHome {
 String get _home {
   final home = Platform.environment['HOME'];
   if (home == null) {
-    throw _NoEnvironmentFoundException(
+    throw EnvironmentNotFoundException(
         'Environment variable \$HOME is not defined!');
   }
   return home;
 }
 
-class _NoEnvironmentFoundException implements IOException {
+class EnvironmentNotFoundException implements Exception {
   final String message;
-  _NoEnvironmentFoundException(this.message);
+  EnvironmentNotFoundException(this.message);
   @override
   String toString() {
     return message;

--- a/test/cli_util_test.dart
+++ b/test/cli_util_test.dart
@@ -49,5 +49,21 @@ void defineTests() {
       // just a dummy check that some part of the path exists.
       expect(Directory(p.joinAll(path.take(2))).existsSync(), isTrue);
     });
+
+    test('Throws IOException when run with empty environment', () {
+      final scriptPath = p.join('test', 'print_config_home.dart');
+      final result = Process.runSync(
+        Platform.resolvedExecutable,
+        [scriptPath],
+        environment: {},
+        includeParentEnvironment: false,
+      );
+      final varName = Platform.isWindows ? '%APPDATA%' : r'$HOME';
+      expect(
+        (result.stdout as String).trim(),
+        'Caught: Environment variable $varName is not defined!',
+      );
+      expect(result.exitCode, 0);
+    });
   });
 }

--- a/test/print_config_home.dart
+++ b/test/print_config_home.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+
+import 'package:cli_util/cli_util.dart';
+
+void main() {
+  try {
+    print(applicationConfigHome('dart'));
+  } on IOException catch (e) {
+    print('Caught: $e');
+  }
+}

--- a/test/print_config_home.dart
+++ b/test/print_config_home.dart
@@ -1,11 +1,9 @@
-import 'dart:io';
-
 import 'package:cli_util/cli_util.dart';
 
 void main() {
   try {
     print(applicationConfigHome('dart'));
-  } on IOException catch (e) {
+  } on EnvironmentNotFoundException catch (e) {
     print('Caught: $e');
   }
 }


### PR DESCRIPTION
It is not always possible to resolve any environment variables - but we still might want to query for the directory if it exists.

We could also make `applicationConfigHome` return a nullable result - but that would be a breaking change, and perhaps this case is better thought of as an exceptional condition.

See: https://github.com/dart-lang/pub/issues/3167 for context.