### PR TITLE
Add customizable Progress

### DIFF
--- a/example/custom_progress.dart
+++ b/example/custom_progress.dart
@@ -11,7 +11,7 @@ Future<void> main(List<String> args) async {
   final progress = CustomProgress(
     refreshPer: const Duration(milliseconds: 50),
     // This callback will be called per 'refreshPer'
-    message: (elapsed) =>
+    messageBuilder: (elapsed) =>
         'Downloading $percentage% (${elapsed.inMilliseconds / 1000.0}s)',
   );
 

--- a/example/custom_progress.dart
+++ b/example/custom_progress.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:cli_util/cli_logging.dart';
+
+Future<void> main(List<String> args) async {
+  var percentage = 0;
+  final progress = CustomProgress(
+    refreshPer: const Duration(milliseconds: 50),
+    // This callback will be called per 'refreshPer'
+    message: (elapsed) =>
+        'Downloading $percentage% (${elapsed.inMilliseconds / 1000.0}s)',
+  );
+
+  while (percentage <= 100) {
+    // Do stuffs...
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    percentage++;
+  }
+
+  progress.finish(message: 'Download: Done!');
+}

--- a/lib/cli_logging.dart
+++ b/lib/cli_logging.dart
@@ -252,23 +252,24 @@ class AnsiProgress extends Progress {
 /// A highly customizable [Progress].
 class CustomProgress extends Progress {
   late final Timer _timer;
-  final String Function(Duration elapsed) _messageBuilder;
   String? _prevMessage;
 
   /// Creates a customizable [Progress].
   ///
-  /// This [Progress] invokes the [message] callback with a [refreshPer] period
-  /// to create a new message and overwrite the current line.
+  /// This [Progress] invokes the [messageBuilder] callback with a [refreshPer]
+  /// period to create a new message and overwrite the current line.
+  /// The [messageBuilder] should return a single line string,
+  /// not including newline characters.
   CustomProgress({
-    required String Function(Duration elapsed) message,
+    required String Function(Duration elapsed) messageBuilder,
+    String message = '',
     Duration refreshPer = const Duration(milliseconds: 80),
-  })  : _messageBuilder = message,
-        super('') {
+  }) : super(message) {
     _timer = Timer.periodic(
       refreshPer,
-      (_) => _updateDisplay(message: _messageBuilder(elapsed)),
+      (_) => _updateDisplay(message: messageBuilder(elapsed)),
     );
-    _updateDisplay(message: _messageBuilder(const Duration()));
+    _updateDisplay(message: messageBuilder(const Duration()));
   }
 
   @override


### PR DESCRIPTION
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

This PR adds a customizable Progress mentioned in #85.

Demo:

https://github.com/dart-lang/cli_util/assets/68946713/3d719207-dc18-466f-bbb8-762a0124cd90

#### Changes made:
- Add `CustomProgress` class that can display an arbitrary single line message with a specific time period
- Add an example of 'CustomProgress'

#### Consideration:
- How should this new progress be integrated with `Logger.progress()`?


I hope you like these changes, thanks!