### PR TITLE
Replace print with stdout.writeln in StandardLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+- Replace `print` with `stdout.writeln` in `StandardLogger` to be in line with
+  all other methods.
+
 ## 0.4.0
 
 - Remove the deprecated method `getSdkDir()` (instead, use `getSdkPath()`).

--- a/lib/cli_logging.dart
+++ b/lib/cli_logging.dart
@@ -136,7 +136,7 @@ class StandardLogger implements Logger {
   void stdout(String message) {
     _cancelProgress();
 
-    print(message);
+    io.stdout.writeln(message);
   }
 
   @override


### PR DESCRIPTION
This PR replaces on instance on `print` with `stdout.writeln` in `StandardLogger`.
When having zones with custom print handling, the use of `print` here may lead to very unexpected outputs.
There is no other place where `print` is used so this is in line with all other logger methods.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
